### PR TITLE
image input types do not allow value

### DIFF
--- a/lib/Devel/ebug/HTTP.pm
+++ b/lib/Devel/ebug/HTTP.pm
@@ -212,9 +212,9 @@ sub codelines {
   # make us slightly more XHTML
   $_ =~ s{<br>}{<br/>} foreach @lines;
 
-  # link module names to search.cpan.org
+  # link module names to metacpan
   @lines = map {
-    $_ =~ s{<span class="word">([^<]+?::[^<]+?)</span>}{<span class="word"><a href="http://search.cpan.org/perldoc?$1">$1</a></span>};
+    $_ =~ s{<span class="word">([^<]+?::[^<]+?)</span>}{<span class="word"><a href="https://metacpan.org/pod/$1">$1</a></span>};
     $_;
   } @lines;
 

--- a/root/icon
+++ b/root/icon
@@ -1,6 +1,20 @@
 <td>
-<table border=0>
-<tr><td><div id="icon_graphic"><input type="image" src="/[% image %]" name="myaction" value="[% text %]"></span></tr></td>
-<tr><td><div id="icon_text">[% text %]</span></td></tr>
-</table>
+  <table border=0>
+    <tr>
+      <td>
+        <div id="icon_graphic">
+          <form name="myform" method="post" action="[% url %]#top">
+            <input type="hidden" name="sequence" value="[% sequence %]"/>
+            <input type="hidden" name="myaction" value="[% text %]"/>
+            <input type="image" src="/[% image %]">
+          </form>
+        </div>
+      </tr>
+    </td>
+    <tr>
+      <td>
+        <div id="icon_text">[% text %]</div>
+      </td>
+    </tr>
+  </table>
 </td>

--- a/root/layout_tail
+++ b/root/layout_tail
@@ -1,5 +1,5 @@
 <div id="version">
-<a href="http://search.cpan.org/dist/Devel-ebug/">Devel::ebug</a> [% ebug.VERSION %]
+<a href="https://metacpan.org/pod/Devel::ebug/">Devel::ebug</a> [% ebug.VERSION %]
 </div>
 
 <form name="hiddenform" method="post" style="visibility:hidden;" action="[% url %]#top">

--- a/root/running
+++ b/root/running
@@ -3,8 +3,6 @@
 
 <div id="body" onFocus = "keys_disabled = 0">
 
-<form name="myform" method="post" action="[% url %]#top">
-<input type="hidden" name="sequence" value="[% sequence %]"/>
 <table id="icon_bar" width="100%">
 <tr>
 [% INCLUDE icon image="stock_undo.png" text="Undo" %]
@@ -16,7 +14,6 @@
 <td width="100%">[% ebug.program | html %] [% subroutine %]([% ebug.filename | html %]#[% ebug.line %])</td>
 </tr>
 </table>
-</form>
 
 <table id="icon_bar" width="100%">
 <tr><td>


### PR DESCRIPTION
According to documentation found on the interwebs.  Older browsers probably incorrectly allowed this which is why it used to work.